### PR TITLE
🔧 Closes #15 update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
-API_KEY_NAME=""
-API_KEY_SECRET=""
-POSTGRES_URL=""
-ENCRYPTION_KEY=""
-NEXT_PUBLIC_CDP_PROJECT_ID=""
+CDP_API_KEY_NAME="your-api-key-name"
+CDP_API_KEY_SECRET="your-api-key-secret"
+ENCRYPTION_KEY="your-encryption-key"
+POSTGRES_URL="postgresql://admin:password@localhost:5432/seeds"
+NEXT_PUBLIC_CDP_PROJECT_ID="your-cdp-project-id"
 MAINNET_DISABLED=false


### PR DESCRIPTION
The .env.example didn't use the `CDP_API_KEY_NAME` and `CDP_API_KEY_SECRET`. Hence, I suggest to update the `.env.example` to align with `README.md` 